### PR TITLE
outdated sms/ and mtt/ references removed.

### DIFF
--- a/README
+++ b/README
@@ -4,6 +4,4 @@ File/Directory  Description
 -------------- --------------------------------------------------------------
 INSTALL        How to compile, install and use the Husky software. READ THIS!
 develop-docs/  Some tips and hints for developers that work on Husky source.
-sms/           Setup at Sascha Silbe's system
-mtt/           Setup at Matthias Tichy's system
 -------------- --------------------------------------------------------------


### PR DESCRIPTION
Those example config directories are already removed from master. They could be reviewed with `git checkout f6fc` 